### PR TITLE
Currency switching broken on mobile devices #Bugfix 🚀

### DIFF
--- a/content/pricing.html
+++ b/content/pricing.html
@@ -341,27 +341,27 @@ function backToEuros() {
           <button class="modal__close" aria-label="Close modal" aria-controls="modal__container1" data-micromodal-close></button>
         </header>
         <div class="container">
-          <button onclick="backToEuros()" data-micromodal-close class="btn btn--block">European Euro (EUR, default)</button>
+          <button onclick="backToEuros()" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">European Euro (EUR, default)</button>
 
-          <button onclick="changeCurrency('USD')" data-micromodal-close class="btn btn--block">American Dollar (USD)</button>
-          <button onclick="changeCurrency('JPY')" data-micromodal-close class="btn btn--block">Japanese Yen (JPY)</button>
-          <button onclick="changeCurrency('GBP')" data-micromodal-close class="btn btn--block">British Pound (GBP)</button>
-          <button onclick="changeCurrency('CHF')" data-micromodal-close class="btn btn--block">Swiss Franc (CHF)</button>
-          <button onclick="changeCurrency('CAD')" data-micromodal-close class="btn btn--block">Canadian Dollar (CAD)</button>
-          <button onclick="changeCurrency('AUD')" data-micromodal-close class="btn btn--block">Australian Dollar (AUD)</button>
-          <button onclick="changeCurrency('NZD')" data-micromodal-close class="btn btn--block">New Zealand Dollar (NZD)</button>
-          <button onclick="changeCurrency('NOK')" data-micromodal-close class="btn btn--block">Norwegian Krone (NOK)</button>
-          <button onclick="changeCurrency('SEK')" data-micromodal-close class="btn btn--block">Swedish Krona (SEK)</button>
-          <button onclick="changeCurrency('RUB')" data-micromodal-close class="btn btn--block">Russian Ruble (RUB)</button>
-          <button onclick="changeCurrency('MXN')" data-micromodal-close class="btn btn--block">Mexican Peso (MXN)</button>
-          <button onclick="changeCurrency('BRL')" data-micromodal-close class="btn btn--block">Bralizian Real (BRL)</button>
-          <button onclick="changeCurrency('ZAR')" data-micromodal-close class="btn btn--block">South African Rand (ZAR)</button>
-          <button onclick="changeCurrency('SGD')" data-micromodal-close class="btn btn--block">Singapore Dollar (SGD)</button>
-          <button onclick="changeCurrency('TRY')" data-micromodal-close class="btn btn--block">Turkish Lira (TRY)</button>
-          <button onclick="changeCurrency('KRW')" data-micromodal-close class="btn btn--block">South Korea Won (KRW)</button>
-          <button onclick="changeCurrency('INR')" data-micromodal-close class="btn btn--block">Indian Rupee (INR)</button>
-          <button onclick="changeCurrency('IDR')" data-micromodal-close class="btn btn--block">Indonesian Rupiah (IDR)</button>
-          <button onclick="changeCurrency('PHP')" data-micromodal-close class="btn btn--block">Philippine Peso (PHP)</button>
+          <button onclick="changeCurrency('USD')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">American Dollar (USD)</button>
+          <button onclick="changeCurrency('JPY')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Japanese Yen (JPY)</button>
+          <button onclick="changeCurrency('GBP')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">British Pound (GBP)</button>
+          <button onclick="changeCurrency('CHF')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Swiss Franc (CHF)</button>
+          <button onclick="changeCurrency('CAD')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Canadian Dollar (CAD)</button>
+          <button onclick="changeCurrency('AUD')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Australian Dollar (AUD)</button>
+          <button onclick="changeCurrency('NZD')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">New Zealand Dollar (NZD)</button>
+          <button onclick="changeCurrency('NOK')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Norwegian Krone (NOK)</button>
+          <button onclick="changeCurrency('SEK')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Swedish Krona (SEK)</button>
+          <button onclick="changeCurrency('RUB')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Russian Ruble (RUB)</button>
+          <button onclick="changeCurrency('MXN')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Mexican Peso (MXN)</button>
+          <button onclick="changeCurrency('BRL')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Bralizian Real (BRL)</button>
+          <button onclick="changeCurrency('ZAR')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">South African Rand (ZAR)</button>
+          <button onclick="changeCurrency('SGD')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Singapore Dollar (SGD)</button>
+          <button onclick="changeCurrency('TRY')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Turkish Lira (TRY)</button>
+          <button onclick="changeCurrency('KRW')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">South Korea Won (KRW)</button>
+          <button onclick="changeCurrency('INR')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Indian Rupee (INR)</button>
+          <button onclick="changeCurrency('IDR')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Indonesian Rupiah (IDR)</button>
+          <button onclick="changeCurrency('PHP')" ontouchstart="this.onclick()" data-micromodal-close class="btn btn--block">Philippine Peso (PHP)</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Issue was occurring due to **onclick** event not getting triggered on touch devices.
Fixed by setting **ontouchstart** event to trigger corresponding onclick events.